### PR TITLE
Avoid quitting on any keyboard event

### DIFF
--- a/src/raytracer.cr
+++ b/src/raytracer.cr
@@ -224,7 +224,7 @@ quit = false
 while true
   SDL::Event.poll do |event|
     case event
-    when SDL::Event::Quit, SDL::Event::Keyboard
+    when SDL::Event::Quit
       quit = true
       break
     end

--- a/src/tv.cr
+++ b/src/tv.cr
@@ -125,7 +125,7 @@ puts "Rects: #{rects.size}"
 while true
   SDL::Event.poll do |event|
     case event
-    when SDL::Event::Quit, SDL::Event::Keyboard
+    when SDL::Event::Quit
       ms = SDL.ticks - start
       puts "#{frames} frames in #{ms} ms"
       puts "Average FPS: #{frames / (ms * 0.001)}"


### PR DESCRIPTION
This fixes a situation when a shortcut like "Cmd + Q" is pressed.

The "Cmd" keydown itself was handled by `when SDL::Event::Keyboard` branch. So program receives `SDL::Event::Quit` event after you hit just the "Cmd" and then you finally press "Q" of "Cmd + Q" combination which causes Terminal app to handle it as well asking if you want to quit.

Another possible fix would be to handle specific combinations but then you'll need to check for left/right modifiers and write a platform specific code for handling Ctrl on Linux and Cmd on MacOS.